### PR TITLE
Update ignored json keys to prevent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
 ## [1.0.0] - 2017-07-09
 ### Added
 - Testing on Ruby 2.3.0 & 2.4.1 (@Evesy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- Update ignored JSON keys to prevent script crashing out
 
 ## [1.0.0] - 2017-07-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Fixed
-- Update ignored JSON keys to prevent script crashing out
+- Update ignored JSON keys to prevent script crashing out (@Evesy)
+
+### Added
+- Config option to provide alternative list of keys to ignore (@Evesy)
 
 ## [1.0.0] - 2017-07-09
 ### Added

--- a/bin/metrics-twemproxy.rb
+++ b/bin/metrics-twemproxy.rb
@@ -36,7 +36,7 @@ require 'json'
 # Twemproxy metrics
 #
 class Twemproxy2Graphite < Sensu::Plugin::Metric::CLI::Graphite
-  SKIP_ROOT_KEYS = %w(service source version uptime timestamp).freeze
+  SKIP_ROOT_KEYS = %w(service source version uptime timestamp total_connections curr_connections).freeze
 
   option :host,
          description: 'Twemproxy stats host to connect to',

--- a/bin/metrics-twemproxy.rb
+++ b/bin/metrics-twemproxy.rb
@@ -69,9 +69,9 @@ class Twemproxy2Graphite < Sensu::Plugin::Metric::CLI::Graphite
          default: 5
 
   option :skip_keys,
-          description: 'Keys to skip when looping through metrics (Comma seperated)',
-          short: '-k KEYS',
-          long: '--skip-keys KEYS'
+         description: 'Keys to skip when looping through metrics (Comma seperated)',
+         short: '-k KEYS',
+         long: '--skip-keys KEYS'
 
   def run
     skip_keys = if config[:skip_keys]


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-twemproxy/issues/2

Tested using Sensu 0.29 & Twemproxy 0.41.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Ignore additional keys in twemproxy's metrics output so that this Sensu check does not attempt to loop through something that is not a hash.

https://github.com/sensu-plugins/sensu-plugins-twemproxy/issues/2 for more info

#### Known Compatablity Issues

None

